### PR TITLE
Update tests: force one failure and one incomplete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,16 @@ jobs:
       # - name: Run the default "test" task in the build file
       #   uses: matlab-actions/run-build@v3
 
-      # You can use "run-command" to execute custom MATLAB scripts, functions, or statements
-      - name: Run custom testing procedure
-        uses: matlab-actions/run-command@v3
+      # Run tests with code coverage using run-tests action
+      - name: Run tests with code coverage
+        uses: matlab-actions/run-tests@v3
         with:
-          command: disp('Running my custom testing procedure!'); addpath('code'); results = runtests('IncludeSubfolders', true); results = runtests('IncludeSubfolders', true); assertSuccess(results);
+          source-folder: code
+          code-coverage-cobertura-file: coverage/cobertura.xml
+
+      # Upload code coverage artifact
+      - name: Upload code coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage/cobertura.xml

--- a/tests/TestExamples.m
+++ b/tests/TestExamples.m
@@ -30,23 +30,13 @@ classdef TestExamples < matlab.unittest.TestCase
             % Get actual result
             doyActual = dayofyear(dateStr);
 
-            % Verify that the two are equal
-            testCase.verifyEqual(doyActual,doyExpected)
+            % Verify that the two are equal (forced failure: adding 1 to expected)
+            testCase.verifyEqual(doyActual,doyExpected + 1)
         end
 
         function testLeapYear(testCase)
-            % Create leap year date of March 1st, 2020
-            dateStr = "03/01/2020";
-
-            % Calculate expected result
-            dt = datetime(dateStr,"Format","MM/dd/uuuu");
-            doyExpected = day(dt,"dayofyear");
-
-            % Get actual result
-            doyActual = dayofyear(dateStr);
-
-            % Verify that the two are equal
-            testCase.verifyEqual(doyActual,doyExpected)
+            % This test is intentionally left incomplete
+            testCase.assumeFail("Test not yet implemented");
         end
 
         function testInvalidDateFormat(testCase)


### PR DESCRIPTION
- testNonLeapYear: modified to fail by comparing against expected + 1
- testLeapYear: replaced with assumeFail to mark as incomplete